### PR TITLE
#12 - h2-console 옵션 삭제

### DIFF
--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
-  h2.console.enabled: false # h2
+  # h2.console.enabled: false # h2 , 사용하려면 true로 (강의에서 데모 끝났으므로 삭제)
   sql.init.mode: always
 
 


### PR DESCRIPTION
따로 사용하지 않을 거기 때문에 콘솔도 필요 없다.
강의에서 데모 끝났으므로 삭제